### PR TITLE
Get geojs from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,20 @@ Post-Minerva:
 
 http://localhost:8080           => serves Minerva
 http://localhost:8080/girder    => serves Girder
+
+
+#### Installing a specific version of GeoJs for development
+
+This is to get around the fact that npm is for installing packages, not managing source repositories.  So when npm installs geojs, it doesn't install it as a git repo with the .git dir.
+
+  1. change the reference in the `geojs` line of package.json to point to the correct branch or sha reference
+  2. run `npm install` from the top level `minerva` directory
+  3. `cd node_modules/geojs`
+  4. `rm -rf vgl`
+  5. `git clone https://github.com/OpenGeoscience/vgl.git`
+  6. find the hash of vgl from the geojs branch
+  7. `cd vgl; git checkout $HASH_FROM_GEOJS_BRANCH; cd ..`
+  8. `npm install` (this time inside geojs)
+  9. `grunt` (inside geojs)
+
+At this point geo.min.js should be rebuilt with the checked out version of vgl, and this will be included the next time minerva is built by `grunt`-ing at the top level of girder.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An application for geospatial analytics.",
   "license": "Apache-2.0",
   "dependencies": {
-    "geojs": "git+ssh://git@kwgitlab.kitware.com:gumbo/geojs.git#clustering",
+    "geojs": "git+ssh://git@github.com:OpenGeoscience/geojs.git#master",
     "JSONPath": "0.10.0"
   }
 }


### PR DESCRIPTION
@aashish24 This is ready for review


I've set the geojs path in package.json to pull from github, which will occur when `npm install` is run at the top level of minerva.

The problem is that this doesn't do a full clone of geojs, it doesn't include the `.git` directory, which is why I was getting silent failures on the `git submodule init` and `git submodule update` calls that I mentioned before.

So I can either 

1) Accept the `geo.min.js` that is built into the project and downloaded when I perform `npm install`.  The problem here is that the `geo.min.js` is fairly out of date as it hasn't been updated for a while.

or

2) Delete the `vgl` subdir, clone `vgl`, update `vgl` to the correct commit sha, then `npm install` and `grunt` within the geojs dir to build a current version of geojs


