### PR TITLE
Install geojs from npm to fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   - $HOME/virtualenv/python2.7.9
   - $HOME/.cache/pip
   - $HOME/build/girder/node_modules
+  - $HOME/build/girder/plugins/minerva/node_modules
 
 sudo: false
 
@@ -24,16 +25,22 @@ addons:
     - libnetcdf-dev
 
 before_install:
-    # move node_modules cache so that git clone girder completes
-    - mv $HOME/build/girder/node_modules $HOME/build/girder_node_modules_tmp
+    # move node_modules caches so that git clone girder completes
+    - mv $HOME/build/girder/node_modules $HOME/build/girder_node_modules_cache
+    - mv $HOME/build/girder/plugins/minerva/node_modules $HOME/build/minerva_node_modules_cache
 
     # minerva has been cloned to OpenGeoscience/minerva by travis
     # girder needs to be cloned and then minerva moved under girder
     - cd "${HOME}"/build
+    # remove existing girder dir, it remains from caching operations
+    - rm -rf girder
     - git clone https://github.com/girder/girder.git
-    # move the node_modules cache to the proper place
-    - mv $HOME/build/girder_node_modules_tmp $HOME/build/girder/node_modules
     - mv OpenGeoscience/minerva girder/plugins
+
+    # move the node_modules caches
+    - mv $HOME/build/girder_node_modules_cache $HOME/build/girder/node_modules
+    - mv $HOME/build/minerva_node_modules_cache $HOME/build/girder/plugins/minerva/node_modules
+
     - cd girder
     # copy the placeholder bsve credentials, needed even though we mock bsve api calls
     - cp plugins/minerva/server/utility/bsve/bsve.json.in plugins/minerva/server/utility/bsve/bsve.json
@@ -65,6 +72,9 @@ before_install:
 install:
     - scripts/InstallPythonRequirements.py --mode=dev --ignore-plugins=${IGNORE_PLUGINS}
     - npm install grunt grunt-cli
+    - pushd plugins/minerva
+    - npm install
+    - popd
     - npm install
     # Create symlink for romanesco plugin
     - ln -s `python -c "import romanesco;import os;print os.path.dirname(romanesco.__file__)"` "${HOME}"/build/girder/plugins/romanesco

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ http://localhost:8080/girder    => serves Girder
 
 This is to get around the fact that npm is for installing packages, not managing source repositories.  So when npm installs geojs, it doesn't install it as a git repo with the .git dir.
 
-Minerva currently tracks the latest released version of geojs from geojs' master branch, as published in geojs/geo.min.js.
+Minerva currently tracks the latest released version of geojs from npm.
 
-If you need to use Minerva with a specific reference of geojs that isn't the current release version held in geojs github repo, do the following
+If you need to use Minerva with a specific reference of geojs that isn't the current release version held in npm, do the following
 
   1. from the minerva top level dir, `cd node_modules`
   2. remove or move geojs, e.g. `mv geojs geojs_fromnpm`

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An application for geospatial analytics.",
   "license": "Apache-2.0",
   "dependencies": {
-    "geojs": "git+ssh://git@github.com:OpenGeoscience/geojs.git#master",
+    "geojs": "0.5.0",
     "JSONPath": "0.10.0"
   }
 }

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -42,5 +42,5 @@ add_javascript_style_test(
 
 add_web_client_test(
     minerva "${PROJECT_SOURCE_DIR}/plugins/minerva/plugin_tests/minervaSpec.js"
-    ENABLEDPLUGINS "gravatar" "jobs" "romanesco"
+    ENABLEDPLUGINS "minerva" "gravatar" "jobs" "romanesco"
     BASEURL "/static/built/testEnvMinerva.html")


### PR DESCRIPTION
This fixes the Travis build, which was breaking because we weren't correctly installing geojs. Now I've changed package.json to install geojs from npm. We still have our instructions in the README that describe how to install any particular branch of geojs from Github.

@kotfic This should make more sense now.  :grinning: 